### PR TITLE
Preload oras://ghcr.io SIF images for better UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ Options:
     -t, --timelimit Slurm timelimit to use (default: 12:00:00)
     -g, --gpus  Number of GPUs to request (default: )
 
+Advanced options:
+    --no-ghcr-oras-preload  Don't preload ORAS GitHub Container Registry images
+
 Extra arguments:
     Any extra arguments will be passed to apptainer run.
     See 'apptainer run --help' for more information.
@@ -308,8 +311,8 @@ When you set an environment variable, it is advisable to surround the value with
 The following variables are available:
 
 - HYAKVNC_DIR: Local directory to store application data (default: `$HOME/.hyakvnc`)
-- HYAKVNC_CHECK_UPDATE_FREQUENCY: How often to check for updates in `[d]`ays or `[m]`inutes (default: `0` for every time. Use `1d` for daily, `10m` for every 10 minutes, etc. `-1` to disable.)
 - HYAKVNC_CONFIG_FILE: Configuration file to use (default: `$HYAKVNC_DIR/hyakvnc-config.env`)
+- HYAKVNC_CHECK_UPDATE_FREQUENCY: How often to check for updates in `[d]`ays or `[m]`inutes (default: `0` for every time. Use `1d` for daily, `10m` for every 10 minutes, etc. `-1` to disable.)
 - HYAKVNC_LOG_FILE: Log file to use (default: `$HYAKVNC_DIR/hyakvnc.log`)
 - HYAKVNC_LOG_LEVEL: Log level to use for interactive output (default: `INFO`)
 - HYAKVNC_LOG_FILE_LEVEL: Log level to use for log file output (default: `DEBUG`)
@@ -317,8 +320,9 @@ The following variables are available:
 - HYAKVNC_DEFAULT_TIMEOUT: Seconds to wait for most commands to complete before timing out (default: `30`)
 - HYAKVNC_VNC_PASSWORD: Password to use for new VNC sessions (default: `password`)
 - HYAKVNC_VNC_DISPLAY: VNC display to use (default: `:1`)
+- HYAKVNC_APPTAINER_CONTAINERS_DIR: Directory to look for apptainer containers (default: (none))
+- HYAKVNC_APPTAINER_GHCR_ORAS_PRELOAD: Whether to preload SIF files from the ORAS GitHub Container Registry (default: `0`)
 - HYAKVNC_APPTAINER_BIN: Name of apptainer binary (default: `apptainer`)
-- HYAKVNC_LOGIN_NODE_APPTAINER_BIN: Path to apptainer binary on login node(default: `/sw/apptainer/default/bin/apptainer`)
 - HYAKVNC_APPTAINER_CONTAINER: Path to container image to use (default: (none; set by `--container` option))
 - HYAKVNC_APPTAINER_APP_VNCSERVER: Name of app in the container that starts the VNC session (default: `vncserver`)
 - HYAKVNC_APPTAINER_APP_VNCKILL: Name of app that cleanly stops the VNC session in the container (default: `vnckill`)

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ ssh your-uw-netid@klone.hyak.uw.edu
 After you've connected to the login node, you can download and install `hyakvnc` by running the following command. Copy and paste it into the terminal window where you are connected to the login node and press enter:
 
 ```bash
-eval "$(curl -fsSL https://raw.githubusercontent.com//maouw/hyakvnc/main/install.sh)"
+eval "$(curl -fsSL https://raw.githubusercontent.com//maouw/hyakvnc/apptainer-pull-cache/install.sh)"
 ```
 
 This will download and install `hyakvnc` to your `~/.local/bin` directory and add it to your `$PATH` so you can run it by typing `hyakvnc` into the terminal window.
@@ -318,6 +318,7 @@ The following variables are available:
 - HYAKVNC_VNC_PASSWORD: Password to use for new VNC sessions (default: `password`)
 - HYAKVNC_VNC_DISPLAY: VNC display to use (default: `:1`)
 - HYAKVNC_APPTAINER_BIN: Name of apptainer binary (default: `apptainer`)
+- HYAKVNC_LOGIN_NODE_APPTAINER_BIN: Path to apptainer binary on login node(default: `/sw/apptainer/default/bin/apptainer`)
 - HYAKVNC_APPTAINER_CONTAINER: Path to container image to use (default: (none; set by `--container` option))
 - HYAKVNC_APPTAINER_APP_VNCSERVER: Name of app in the container that starts the VNC session (default: `vncserver`)
 - HYAKVNC_APPTAINER_APP_VNCKILL: Name of app that cleanly stops the VNC session in the container (default: `vnckill`)

--- a/ghcr_get_token.sh
+++ b/ghcr_get_token.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# # Apptainer utility functions:
+set -o pipefail
+shopt -s checkwinsize
+set -m
+
+function log {
+	echo "$*"
+}
+
+# ghcr_get_token_for_repo()
+# Get a GitHub Container Registry token for a given repository
+# Arguments: <url> (required)
+# Returns: 0 if successful, 1 if not or if an error occurred
+# Prints: The token to stdout
+function ghcr_get_size_for_oras_image {
+	local url image_ref repo repo_token image_tag manifest layer_size
+	command -v curl >/dev/null 2>&1 || {
+		log ERROR "curl is not installed!"
+		return 1
+	}
+	command -v python3 >/dev/null 2>&1 || {
+		log ERROR "python3 is not installed!"
+		return 1
+	}
+
+	url="${1:-}"
+	[[ -z "${url}" ]] && {
+		log ERROR "URL must be specified"
+		return 1
+	}
+
+	case "${url}" in
+	ghcr.io/*)
+		image_ref="${url#ghcr.io/}"
+		repo="${image_ref%%:*}"
+		image_tag="${image_ref##*:}"
+		;;
+	*) # Not a GitHub Container Registry URL
+		log ERROR "URL ${url} is not a GitHub Container Registry URL"
+		return 1
+		;;
+	esac
+
+	repo_token="$(curl -sSL "https://ghcr.io/token?scope=repository:${repo}:pull&service=ghcr.io" | python3 -I -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null || true)"
+	[[ -z "${repo_token}" ]] && {
+		log ERROR "Failed to get token for repository ${repo}"
+		return 1
+	}
+	
+	manifest="$(curl -sSL -H "Accept: application/vnd.oci.image.manifest.v1+json" -H "Authorization: Bearer ${repo_token}" "https://ghcr.io/v2/${repo}/manifests/${image_tag}")"
+	[[ -z "${manifest}" ]] && {
+		log ERROR "Failed to get manifest for repository ${repo}"
+		return 1
+	}
+	layer_size=$(echo "${manifest}" | python3 -I -c 'import sys,json; v=json.load(sys.stdin); sys.exit(1) if len(v["layers"]) != 1 or not v["layers"][0]["mediaType"].startswith("application/vnd.sylabs.sif.layer") else print(v["layers"][0]["size"])' 2>/dev/null || true)
+	[[ -z "${layer_size}" ]] && {
+		log ERROR "Failed to get layer size for repository ${repo}"
+		return 1
+	}
+
+	echo "${layer_size}"
+	return 0
+}
+
+function progress_bar {
+	local current total filled empty cols
+	local current="${1:-}"
+    local total="${2:-}"
+	cols="${3:-}"
+	[[ -z "${cols:-}" ]] && cols="$(tput cols)"
+
+
+	filled=$((current*${cols}/total))
+    empty=$((${cols}-filled))
+
+    printf "["
+	printf -- '#%.0s' {1..${filled}}
+	printf -- ' %.0s' {1..${empty}}
+	printf "]"
+
+
+	for ((i=0;i<${empty};i++)); do
+        printf " "
+    done
+    printf "]\n"
+}
+
+function bytes_to_human {
+    local bytes=$1
+    if [[ ${bytes} -lt 1024 ]]; then
+        echo "${bytes}B"
+    elif [[ ${bytes} -lt 1048576 ]]; then
+        echo $((bytes/1024))"KB"
+    elif [[ ${bytes} -lt 1073741824 ]]; then
+        echo $((bytes/1048576))"MB"
+    else
+        echo $((bytes/1073741824))"GB"
+    fi
+}
+
+function precache_interactive {
+	local pid oras_tmp_path total_size current_size
+	pid="${1:-}"
+	[[ -z "${pid}" ]] && {
+		log ERROR "PID must be specified"
+		return 1
+	}
+	total_size="${2:-}"
+	[[ -z "${total_size}" ]] && {
+		log ERROR "Total size must be specified"
+		return 1
+	}
+
+	command -v find >/dev/null 2>&1 || {
+		log ERROR "find is not installed!"
+		return 1
+	}
+
+    oras_tmp_path=$(find /proc/$pid/fd -type l -xtype f -lname '*apptainer*/oras/*tmp*' -printf '%l\n' -quit || true)
+	[[ -z "${oras_tmp_path}" ]] && {
+		log ERROR "Failed to find oras tmp path for PID ${pid}"
+		return 1
+	}
+
+	while current_size="$(du -sb "${oras_tmp_path}" 2>/dev/null | cut -f1)"; do
+		printf "Downloading image: %s / %s\n" "$(bytes_to_human "${current_size}" || true)" "$(bytes_to_human "${total_size}" || true)"
+		sleep 1
+		printf "\e[1A"
+	done
+	printf "\n"
+}
+
+url="${1:-ghcr.io/maouw/ubuntu22.04_turbovnc:latest}"
+tmpfile="$(mktemp --suffix ".ghcr.oras.sif")"
+trap 'kill -9 ${pidno}; echo killed ${pidno}; rm -rf "${tmpfile:-}"' EXIT TERM SIGTERM SIGQUIT
+
+apptainer pull -F "${tmpfile}" "oras://${url}" 1>/dev/null 2>/dev/null &
+pidno="${!}"
+echo "PID: ${pidno}"
+sleep 5
+size="$(ghcr_get_size_for_oras_image "${url}")"
+precache_interactive "${pidno}" "${size}"
+
+wait  "${pidno}"
+rm -f "${tmpfile}"

--- a/hyakvnc
+++ b/hyakvnc
@@ -1090,8 +1090,6 @@ function cmd_create {
 	export HYAKVNC_SLURM_JOB_NAME="${HYAKVNC_SLURM_JOB_PREFIX}${container_name}"
 	export SBATCH_JOB_NAME="${HYAKVNC_SLURM_JOB_NAME}" && log TRACE "Set SBATCH_JOB_NAME to ${SBATCH_JOB_NAME}"
 
-	log INFO "Creating HyakVNC job named \"${HYAKVNC_SLURM_JOB_NAME}\" for container ${container_basename}"
-
 	# Set sbatch arguments or environment variables:
 	#   CPUs has to be specified as a sbatch argument because it's not settable by environment variable:
 	[[ -n "${HYAKVNC_SLURM_CPUS:-}" ]] && sbatch_args+=(--cpus-per-task "${HYAKVNC_SLURM_CPUS}") && log TRACE "Set --cpus-per-task to ${HYAKVNC_SLURM_CPUS}"
@@ -1147,7 +1145,7 @@ function cmd_create {
 	# Trap signals to clean up the job if the user exits the script:
 	[[ -z "${XNOTRAP:-}" ]] && trap cleanup_launched_jobs_and_exit SIGINT SIGTERM SIGHUP SIGABRT SIGQUIT ERR EXIT
 
-	log INFO "Launching job with command: sbatch ${sbatch_args[*]}"
+	log DEBUG "Launching job with command: sbatch ${sbatch_args[*]}"
 
 	sbatch_result=$(sbatch "${sbatch_args[@]}") || {
 		log ERROR "Failed to launch job"
@@ -1174,10 +1172,11 @@ function cmd_create {
 	log DEBUG "Job directory: ${jobdir}"
 
 	# Wait for sbatch job to start running by monitoring the output of squeue:
+	log INFO "Waiting for job ${launched_jobid} (\"${HYAKVNC_SLURM_JOB_NAME}\") to start"
 	start=${EPOCHSECONDS:-}
 	while true; do
 		if ((EPOCHSECONDS - start > HYAKVNC_SLURM_SUBMIT_TIMEOUT)); then
-			log ERROR "Timed out waiting for job to start"
+			log ERROR "Timed out waiting for job ${launched_jobid} to start"
 			exit 1
 		fi
 		sleep 1

--- a/hyakvnc
+++ b/hyakvnc
@@ -790,10 +790,20 @@ function ghcr_get_oras_sif {
 		log ERROR "Failed to get image info for repository ${repo}"
 		return 1
 	}
-	[[ -d "${output_path}" ]] && output_path="${output_path}/${image_sha256}" # Append the image SHA256 to the output path if it's a directory
-	[[ -e "${output_path}" ]] && {
+	[[ -d "${output_path}" ]] && output_path="${output_path}/sha256:${image_sha256}" # Append the image SHA256 to the output path if it's a directory
+
+	if [[ -r "${output_path}" ]]; then
 		log DEBUG "Image already exists at ${output_path}"
-	}
+		if check_command sha256sum; then
+			if sha256sum --quiet --status --ignore-missing --check <(echo "${output_path}" "${image_sha256}"); then
+				log DEBUG "Image at ${output_path} matches expected SHA256 ${image_sha256}"
+				echo "${output_path}"
+				return 0
+			else
+				log DEBUG "Image at ${output_path} does not match expected SHA256 ${image_sha256}. Will redownload and overwrite."
+			fi
+		fi
+	fi
 
 	# Download the image:
 	local image_url

--- a/hyakvnc
+++ b/hyakvnc
@@ -1078,7 +1078,7 @@ function cmd_create {
 		oras_cache_dir="${APPTAINER_CACHEDIR:-${HOME}/.apptainer/cache}/cache/oras"
 		if mkdir -p "${oras_cache_dir}"; then
 			log INFO "Preloading ORAS image for \"${HYAKVNC_APPTAINER_CONTAINER}\""
-			oras_image_path="$(ghcr_get_oras_sif "${HYAKVNC_APPTAINER_CONTAINER}" "${APPTAINER_CACHEDIR}/cache/oras" 1>/dev/null || true)"
+			oras_image_path="$(ghcr_get_oras_sif "${HYAKVNC_APPTAINER_CONTAINER}" "${APPTAINER_CACHEDIR}/cache/oras" || true)"
 			[[ -z "${oras_image_path:-}" ]] && log ERROR "hyakvnc failed to preload ORAS image for \"${HYAKVNC_APPTAINER_CONTAINER:-}\" on its own. Apptainer will try to download the image by itself. If you don't want to preload ORAS images, use the --no-ghcr-oras-preload option."
 		else
 			log ERROR "Failed to create directory ${oras_cache_dir}."

--- a/hyakvnc
+++ b/hyakvnc
@@ -790,12 +790,12 @@ function ghcr_get_oras_sif {
 		log ERROR "Failed to get image info for repository ${repo}"
 		return 1
 	}
-	[[ -d "${output_path}" ]] && output_path="${output_path}/sha256:${image_sha256}" # Append the image SHA256 to the output path if it's a directory
+	[[ -d "${output_path}" ]] && output_path="${output_path}/${image_sha256}" # Append the image SHA256 to the output path if it's a directory
 
 	if [[ -r "${output_path}" ]]; then
 		log DEBUG "Image already exists at ${output_path}"
 		if check_command sha256sum; then
-			if sha256sum --quiet --status --ignore-missing --check <(echo "${output_path}" "${image_sha256}"); then
+			if sha256sum --quiet --status --ignore-missing --check <(echo "${output_path}" "${image_sha256##sha256:}"); then
 				log DEBUG "Image at ${output_path} matches expected SHA256 ${image_sha256}"
 				echo "${output_path}"
 				return 0

--- a/hyakvnc
+++ b/hyakvnc
@@ -74,7 +74,7 @@ HYAKVNC_MACOS_VNC_VIEWER_BUNDLEIDS="${HYAKVNC_MACOS_VNC_VIEWER_BUNDLEIDS:-com.tu
 # ## Apptainer preferences:
 HYAKVNC_APPTAINER_BIN="${HYAKVNC_APPTAINER_BIN:-apptainer}" # %% Name of apptainer binary (default: `apptainer`)
 
-HYAKVNC_LOGIN_NODE_APPTAINER_BIN="${HYAKVNC_LOGIN_NODE_APPTAINER_BIN:-/sw/apptainer/default/bin/apptainer}" # Path to apptainer binary on login node(default: `/sw/apptainer/default/bin/apptainer`)
+HYAKVNC_LOGIN_NODE_APPTAINER_BIN="${HYAKVNC_LOGIN_NODE_APPTAINER_BIN:-/sw/apptainer/default/bin/apptainer}" # %% Path to apptainer binary on login node(default: `/sw/apptainer/default/bin/apptainer`)
 
 HYAKVNC_APPTAINER_CONTAINER="${HYAKVNC_APPTAINER_CONTAINER:-}" # %% Path to container image to use (default: (none; set by `--container` option))
 
@@ -717,6 +717,83 @@ function cleanup_launched_jobs_and_exit {
 	exit 1
 }
 
+
+# # Apptainer utility functions:
+
+# ghcr_get_token_for_repo()
+# Get a GitHub Container Registry token for a given repository
+# Arguments: <url> (required)
+# Returns: 0 if successful, 1 if not or if an error occurred
+# Prints: The token to stdout
+function ghcr_get_token_for_oras_image {
+	local url image_ref repo repo_token image_tag
+	command -v curl >/dev/null 2>&1 || {
+		log ERROR "curl is not installed!"
+		return 1
+	}
+	command -v python3 >/dev/null 2>&1 || {
+		log ERROR "python3 is not installed!"
+		return 1
+	}
+
+	url="${1:-}"
+	[[ -z "${url}" ]] && {
+		log ERROR "URL must be specified"
+		return 1
+	}
+
+	case "${url}" in
+	ghcr.io/*)
+		image_ref="${url#ghcr.io/}"
+		repo="${image_ref%%:*}"
+		image_tag="${image_ref##*:}"
+		;;
+	*) # Not a GitHub Container Registry URL
+		log ERROR "URL ${url} is not a GitHub Container Registry URL"
+		return 1
+		;;
+	esac
+
+	repo_token="$(curl -sSL "https://ghcr.io/token?scope=repository:${repo}:pull&service=ghcr.io" | python3 -I -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null || true)"
+	[[ -z "${repo_token}" ]] && {
+		log ERROR "Failed to get token for repository ${repo}"
+		return 1
+	}
+	
+	manifest="$(curl -vsSL -H "Accept: application/vnd.oci.image.manifest.v1+json" -H "Authorization: Bearer ${repo_token}" "https://ghcr.io/v2/${repo}/manifests/${image_tag}")"
+	[[ -z "${manifest}" ]] && {
+		log ERROR "Failed to get manifest for repository ${repo}"
+		return 1
+	}
+	layer_size=$(echo "${manifest}" | /usr/bin/python3.6 -I -c 'import sys,json; v=json.load(sys.stdin); sys.exit(1) if len(v["layers"]) == 2 else print(v["layers"][0]["size"])' 2>/dev/null || true)
+	[[ -z "${layer_size}" ]] && {
+		log ERROR "Failed to get layer size for repository ${repo}"
+		return 1
+	}
+
+	echo "${layer_size}"
+	return 0
+}
+
+# precache_remote_apptainer_image()
+# Pull the remote apptainer image to the local cache
+# This is intended to run on the login node and primarily exists to better inform the user about download progress.
+# (The `apptainer pull` progress indicator is difficult to pipe in to the user interface from a remote node.)
+# This depends on the apptainer executable being available on the login node.
+# Arguments: <url> (required), <output_path> (optional)
+# Environment variables:
+# 	- $HYAKVNC_APPTAINER_CACHE_DIR : The directory to use for the apptainer cache
+#	- $HYAKVNC_LOGIN_APPTAINER_PATH : The path to the apptainer executable on the login node
+function precache_remote_apptainer_image {
+	local url output_path
+	url="${1:-}"
+	output_path="${2:-/dev/null}"
+	[[ -z "${HYAKVNC_LOGIN_NODE_APPTAINER_BIN:-}" ]] && { log ERROR "Couldn't find apptainer binary: HYAKVNC_LOGIN_NODE_APPTAINER_BIN is unset or empty."; return 1; }
+	[[ ! -e "${HYAKVNC_LOGIN_NODE_APPTAINER_BIN:-}" ]] && { log ERROR "Apptainer binary not found at HYAKVNC_LOGIN_NODE_APPTAINER_BIN=${HYAKVNC_APPTAINER_BIN:-}"; return 1; }
+	[[ ! -x "${HYAKVNC_LOGIN_NODE_APPTAINER_BIN:-}" ]] && { log ERROR "Apptainer binary not executable (HYAKVNC_LOGIN_NODE_APPTAINER_BIN=${HYAKVNC_APPTAINER_BIN:-})"; return 1; }
+	"${HYAKVNC_LOGIN_NODE_APPTAINER_BIN}" t
+
+}
 # # Commands
 
 # ## Command: create

--- a/hyakvnc
+++ b/hyakvnc
@@ -30,15 +30,8 @@ fi
 HYAKVNC_VERSION="0.3.1"
 
 # ## App preferences:
-HYAKVNC_DIR="${HYAKVNC_DIR:-${HOME}/.hyakvnc}"                        # %% Local directory to store application data (default: `$HOME/.hyakvnc`)
-HYAKVNC_REPO_DIR="${HYAKVNC_REPO_DIR:-${HYAKVNC_DIR}/hyakvnc}"        # Local directory to store git repository (default: `$HYAKVNC_DIR/hyakvnc`)
-HYAKVNC_CHECK_UPDATE_FREQUENCY="${HYAKVNC_CHECK_UPDATE_FREQUENCY:-0}" # %% How often to check for updates in `[d]`ays or `[m]`inutes (default: `0` for every time. Use `1d` for daily, `10m` for every 10 minutes, etc. `-1` to disable.)
-HYAKVNC_CONFIG_FILE="${HYAKVNC_DIR}/hyakvnc-config.env"               # %% Configuration file to use (default: `$HYAKVNC_DIR/hyakvnc-config.env`)
-HYAKVNC_LOG_FILE="${HYAKVNC_LOG_FILE:-${HYAKVNC_DIR}/hyakvnc.log}"    # %% Log file to use (default: `$HYAKVNC_DIR/hyakvnc.log`)
-HYAKVNC_LOG_LEVEL="${HYAKVNC_LOG_LEVEL:-INFO}"                        # %% Log level to use for interactive output (default: `INFO`)
-HYAKVNC_LOG_FILE_LEVEL="${HYAKVNC_LOG_FILE_LEVEL:-DEBUG}"             # %% Log level to use for log file output (default: `DEBUG`)
-HYAKVNC_SSH_HOST="${HYAKVNC_SSH_HOST:-klone.hyak.uw.edu}"             # %% Default SSH host to use for connection strings (default: `klone.hyak.uw.edu`)
-HYAKVNC_DEFAULT_TIMEOUT="${HYAKVNC_DEFAULT_TIMEOUT:-30}"              # %% Seconds to wait for most commands to complete before timing out (default: `30`)
+HYAKVNC_DIR="${HYAKVNC_DIR:-${HOME}/.hyakvnc}"          # %% Local directory to store application data (default: `$HOME/.hyakvnc`)
+HYAKVNC_CONFIG_FILE="${HYAKVNC_DIR}/hyakvnc-config.env" # %% Configuration file to use (default: `$HYAKVNC_DIR/hyakvnc-config.env`)
 
 # hyakvnc_load_config()
 # Load the hyakvnc configuration from the config file
@@ -65,6 +58,14 @@ if ! (return 0 2>/dev/null); then
 	hyakvnc_load_config
 fi
 
+HYAKVNC_REPO_DIR="${HYAKVNC_REPO_DIR:-${HYAKVNC_DIR}/hyakvnc}"        # Local directory to store git repository (default: `$HYAKVNC_DIR/hyakvnc`)
+HYAKVNC_CHECK_UPDATE_FREQUENCY="${HYAKVNC_CHECK_UPDATE_FREQUENCY:-0}" # %% How often to check for updates in `[d]`ays or `[m]`inutes (default: `0` for every time. Use `1d` for daily, `10m` for every 10 minutes, etc. `-1` to disable.)
+HYAKVNC_LOG_FILE="${HYAKVNC_LOG_FILE:-${HYAKVNC_DIR}/hyakvnc.log}"    # %% Log file to use (default: `$HYAKVNC_DIR/hyakvnc.log`)
+HYAKVNC_LOG_LEVEL="${HYAKVNC_LOG_LEVEL:-INFO}"                        # %% Log level to use for interactive output (default: `INFO`)
+HYAKVNC_LOG_FILE_LEVEL="${HYAKVNC_LOG_FILE_LEVEL:-DEBUG}"             # %% Log level to use for log file output (default: `DEBUG`)
+HYAKVNC_SSH_HOST="${HYAKVNC_SSH_HOST:-klone.hyak.uw.edu}"             # %% Default SSH host to use for connection strings (default: `klone.hyak.uw.edu`)
+HYAKVNC_DEFAULT_TIMEOUT="${HYAKVNC_DEFAULT_TIMEOUT:-30}"              # %% Seconds to wait for most commands to complete before timing out (default: `30`)
+
 # ## VNC preferences:
 HYAKVNC_VNC_PASSWORD="${HYAKVNC_VNC_PASSWORD:-password}" # %% Password to use for new VNC sessions (default: `password`)
 HYAKVNC_VNC_DISPLAY="${HYAKVNC_VNC_DISPLAY:-:10}"        # %% VNC display to use (default: `:1`)
@@ -72,15 +73,12 @@ HYAKVNC_VNC_DISPLAY="${HYAKVNC_VNC_DISPLAY:-:10}"        # %% VNC display to use
 HYAKVNC_MACOS_VNC_VIEWER_BUNDLEIDS="${HYAKVNC_MACOS_VNC_VIEWER_BUNDLEIDS:-com.turbovnc.vncviewer.VncViewer com.realvnc.vncviewer com.tigervnc.vncviewer}" # macOS bundle identifiers for VNC viewer executables (default: `com.turbovnc.vncviewer com.realvnc.vncviewer com.tigervnc.vncviewer`)
 
 # ## Apptainer preferences:
-HYAKVNC_APPTAINER_BIN="${HYAKVNC_APPTAINER_BIN:-apptainer}" # %% Name of apptainer binary (default: `apptainer`)
-
-HYAKVNC_LOGIN_NODE_APPTAINER_BIN="${HYAKVNC_LOGIN_NODE_APPTAINER_BIN:-/sw/apptainer/default/bin/apptainer}" # %% Path to apptainer binary on login node(default: `/sw/apptainer/default/bin/apptainer`)
-
-HYAKVNC_APPTAINER_CONTAINER="${HYAKVNC_APPTAINER_CONTAINER:-}" # %% Path to container image to use (default: (none; set by `--container` option))
-
-HYAKVNC_APPTAINER_APP_VNCSERVER="${HYAKVNC_APPTAINER_APP_VNCSERVER:-vncserver}" # %% Name of app in the container that starts the VNC session (default: `vncserver`)
-HYAKVNC_APPTAINER_APP_VNCKILL="${HYAKVNC_APPTAINER_APP_VNCKILL:-vnckill}"       # %% Name of app that cleanly stops the VNC session in the container (default: `vnckill`)
-
+HYAKVNC_APPTAINER_CONTAINERS_DIR="${HYAKVNC_APPTAINER_CONTAINERS_DIR:-}"                               # %% Directory to look for apptainer containers (default: (none))
+HYAKVNC_APPTAINER_GHCR_ORAS_PRELOAD="${HYAKVNC_APPTAINER_GHCR_ORAS_PRELOAD:-1}"                        # %% Whether to preload SIF files from the ORAS GitHub Container Registry (default: `0`)
+HYAKVNC_APPTAINER_BIN="${HYAKVNC_APPTAINER_BIN:-apptainer}"                                            # %% Name of apptainer binary (default: `apptainer`)
+HYAKVNC_APPTAINER_CONTAINER="${HYAKVNC_APPTAINER_CONTAINER:-}"                                         # %% Path to container image to use (default: (none; set by `--container` option))
+HYAKVNC_APPTAINER_APP_VNCSERVER="${HYAKVNC_APPTAINER_APP_VNCSERVER:-vncserver}"                        # %% Name of app in the container that starts the VNC session (default: `vncserver`)
+HYAKVNC_APPTAINER_APP_VNCKILL="${HYAKVNC_APPTAINER_APP_VNCKILL:-vnckill}"                              # %% Name of app that cleanly stops the VNC session in the container (default: `vnckill`)
 HYAKVNC_APPTAINER_WRITABLE_TMPFS="${HYAKVNC_APPTAINER_WRITABLE_TMPFS:-${APPTAINER_WRITABLE_TMPFS:-1}}" # %% Whether to use a writable tmpfs for the container (default: `1`)
 HYAKVNC_APPTAINER_CLEANENV="${HYAKVNC_APPTAINER_CLEANENV:-${APPTAINER_CLEANENV:-1}}"                   # %% Whether to use a clean environment for the container (default: `1`)
 HYAKVNC_APPTAINER_ADD_BINDPATHS="${HYAKVNC_APPTAINER_ADD_BINDPATHS:-}"                                 # %% Bind paths to add to the container (default: (none))
@@ -221,10 +219,7 @@ function hyakvnc_pull_updates() {
 function hyakvnc_check_updates {
 	log DEBUG "Checking for updates... "
 	# Check if git is installed:
-	command -v git >/dev/null 2>&1 || {
-		log WARN "git is not installed. Can't check for updates"
-		return 1
-	}
+	check_command git ERROR || return 1
 
 	# Check if git is available and that the git directory is a valid git repository:
 	git -C "${HYAKVNC_REPO_DIR}" tag >/dev/null 2>&1 || {
@@ -359,14 +354,22 @@ function hyakvnc_autoupdate {
 	return 0
 }
 
-# ## SLURM utility functons:
+# ## General utility functions:
 
-# check_slurm_installed()
-# Check if SLURM is installed
-# Arguments: None
-function check_slurm_installed {
-	command -v squeue >/dev/null 2>&1 || return 1
+# check_command()
+# Check if a command is available
+# Arguments:
+# - <command> - The command to check
+# - <loglevel> <message> - Passed to log if the command is not available (optional)
+function check_command {
+	if [[ -z "${1:-}" ]] || ! command -v "${1}" >/dev/null 2>&1; then
+		[[ $# -gt 1 ]] && log "${@:2}"
+		return 1
+	fi
+	return 0
 }
+
+# ## SLURM utility functons:
 
 # check_slurm_running {
 # Check if SLURM is running
@@ -461,7 +464,7 @@ function hyakvnc_config_init {
 		return 1
 	}
 
-	if ! check_slurm_installed; then
+	if ! check_command squeue; then
 		log ERROR "SLURM is not installed! Can't initialize configuration."
 		return 1
 	fi
@@ -717,83 +720,95 @@ function cleanup_launched_jobs_and_exit {
 	exit 1
 }
 
-
 # # Apptainer utility functions:
 
-# ghcr_get_token_for_repo()
+# ghcr_get_oras_sif()
 # Get a GitHub Container Registry token for a given repository
 # Arguments: <url> (required)
 # Returns: 0 if successful, 1 if not or if an error occurred
 # Prints: The token to stdout
-function ghcr_get_token_for_oras_image {
-	local url image_ref repo repo_token image_tag
-	command -v curl >/dev/null 2>&1 || {
-		log ERROR "curl is not installed!"
-		return 1
-	}
-	command -v python3 >/dev/null 2>&1 || {
-		log ERROR "python3 is not installed!"
-		return 1
-	}
-
-	url="${1:-}"
-	[[ -z "${url}" ]] && {
+function ghcr_get_oras_sif {
+	check_command curl || return 1    # Check if curl is installed
+	check_command python3 || return 1 # Check if python3 is installed
+	local url output_path
+	[[ -z "${url:=${1:-}}" ]] && {
 		log ERROR "URL must be specified"
 		return 1
 	}
+	output_path="${2:-./}" # Optionally set the output file
+	[[ -d "${output_path}" ]] && [[ ! -w "${output_path}" ]] && {
+		log ERROR "Output directory \"${output_path}\" is not writable"
+		return 1
+	}
 
+	# Check that the URL is an ORAS GitHub Container Registry URL:
+	local address image_ref repo image_tag
 	case "${url}" in
-	ghcr.io/*)
-		image_ref="${url#ghcr.io/}"
+	oras://ghcr.io/*)
+		address="${url#oras://}"
+		image_ref="${address#ghcr.io/}"
 		repo="${image_ref%%:*}"
-		image_tag="${image_ref##*:}"
+		[[ -z "${repo}" ]] && {
+			log ERROR "Failed to parse repository from URL \"${url}\""
+			return 1
+		}
+		[[ ${image_ref} == *:* ]] && image_tag="${image_ref##*:}"
+		image_tag="${image_tag:-latest}"
 		;;
 	*) # Not a GitHub Container Registry URL
-		log ERROR "URL ${url} is not a GitHub Container Registry URL"
+		log ERROR "URL \"${url}\" is not a GitHub Container Registry URL for an ORAS image"
 		return 1
 		;;
 	esac
 
+	# Get a token for the repository (required to get the manifest, but freely available by this request):
+	# Uses curl to get the token, then python to parse the JSON response
+	local repo_token
 	repo_token="$(curl -sSL "https://ghcr.io/token?scope=repository:${repo}:pull&service=ghcr.io" | python3 -I -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null || true)"
 	[[ -z "${repo_token}" ]] && {
 		log ERROR "Failed to get token for repository ${repo}"
 		return 1
 	}
-	
-	manifest="$(curl -vsSL -H "Accept: application/vnd.oci.image.manifest.v1+json" -H "Authorization: Bearer ${repo_token}" "https://ghcr.io/v2/${repo}/manifests/${image_tag}")"
+
+	# Request the manifest for the image tag:
+	local manifest
+	manifest="$(curl -sSL \
+		-H "Accept: application/vnd.oci.image.manifest.v1+json" \
+		-H "Authorization: Bearer ${repo_token}" \
+		"https://ghcr.io/v2/${repo}/manifests/${image_tag}" \
+		2>/dev/null || true)"
 	[[ -z "${manifest}" ]] && {
 		log ERROR "Failed to get manifest for repository ${repo}"
 		return 1
 	}
-	layer_size=$(echo "${manifest}" | /usr/bin/python3.6 -I -c 'import sys,json; v=json.load(sys.stdin); sys.exit(1) if len(v["layers"]) == 2 else print(v["layers"][0]["size"])' 2>/dev/null || true)
-	[[ -z "${layer_size}" ]] && {
-		log ERROR "Failed to get layer size for repository ${repo}"
+
+	local image_sha256
+	image_sha256="$(echo "${manifest}" | python3 -I -c \
+		'import sys, json; s=[ x for x in json.load(sys.stdin)["layers"] if x.get("mediaType", "") == "application/vnd.sylabs.sif.layer.v1.sif" and x.get("digest", "").startswith("sha256")]; sys.exit(1) if len(s) != 1 else print(s[0]["digest"])' \
+		2>/dev/null || true)"
+	[[ -z "${image_sha256:-}" ]] && {
+		log ERROR "Failed to get image info for repository ${repo}"
 		return 1
 	}
+	[[ -d "${output_path}" ]] && output_path="${output_path}/${image_sha256}" # Append the image SHA256 to the output path if it's a directory
+	[[ -e "${output_path}" ]] && {
+		log DEBUG "Image already exists at ${output_path}"
+	}
 
-	echo "${layer_size}"
+	# Download the image:
+	local image_url
+	image_url="https://ghcr.io/v2/${repo}/blobs/${image_sha256}"
+	curl -fSL -H "Authorization: Bearer ${repo_token}" -o "${output_path}" "${image_url}" || {
+		log ERROR "Failed to download image from ${image_url} to ${output_path}"
+		rm -f "${output_path}" && log DEBUG "Removed output file at ${output_path}" # Remove the file if it exists
+		return 1
+	}
+	chmod +x "${output_path}"
+	log DEBUG "Downloaded image to ${output_path}"
+	echo "${output_path}"
 	return 0
 }
 
-# precache_remote_apptainer_image()
-# Pull the remote apptainer image to the local cache
-# This is intended to run on the login node and primarily exists to better inform the user about download progress.
-# (The `apptainer pull` progress indicator is difficult to pipe in to the user interface from a remote node.)
-# This depends on the apptainer executable being available on the login node.
-# Arguments: <url> (required), <output_path> (optional)
-# Environment variables:
-# 	- $HYAKVNC_APPTAINER_CACHE_DIR : The directory to use for the apptainer cache
-#	- $HYAKVNC_LOGIN_APPTAINER_PATH : The path to the apptainer executable on the login node
-function precache_remote_apptainer_image {
-	local url output_path
-	url="${1:-}"
-	output_path="${2:-/dev/null}"
-	[[ -z "${HYAKVNC_LOGIN_NODE_APPTAINER_BIN:-}" ]] && { log ERROR "Couldn't find apptainer binary: HYAKVNC_LOGIN_NODE_APPTAINER_BIN is unset or empty."; return 1; }
-	[[ ! -e "${HYAKVNC_LOGIN_NODE_APPTAINER_BIN:-}" ]] && { log ERROR "Apptainer binary not found at HYAKVNC_LOGIN_NODE_APPTAINER_BIN=${HYAKVNC_APPTAINER_BIN:-}"; return 1; }
-	[[ ! -x "${HYAKVNC_LOGIN_NODE_APPTAINER_BIN:-}" ]] && { log ERROR "Apptainer binary not executable (HYAKVNC_LOGIN_NODE_APPTAINER_BIN=${HYAKVNC_APPTAINER_BIN:-})"; return 1; }
-	"${HYAKVNC_LOGIN_NODE_APPTAINER_BIN}" t
-
-}
 # # Commands
 
 # ## Command: create
@@ -817,6 +832,9 @@ Options:
 	-m, --mem	Amount of memory to request (default: ${HYAKVNC_SLURM_MEM})
 	-t, --timelimit	Slurm timelimit to use (default: ${HYAKVNC_SLURM_TIMELIMIT})
 	-g, --gpus	Number of GPUs to request (default: ${HYAKVNC_SLURM_GPUS})
+
+Advanced options:
+	--no-ghcr-oras-preload	Don't preload ORAS GitHub Container Registry images
 
 Extra arguments:
 	Any extra arguments will be passed to apptainer run.
@@ -915,6 +933,10 @@ function cmd_create {
 			export HYAKVNC_SLURM_GPUS="${1:-}"
 			shift
 			;;
+		--no-ghcr-oras-preload) # Don't preload ORAS GitHub Container Registry images
+			shift
+			export HYAKVNC_APPTAINER_GHCR_ORAS_PRELOAD=0
+			;;
 		--) # Args to pass to Apptainer
 			shift
 			if [[ -z "${HYAKVNC_APPTAINER_ADD_ARGS:-}" ]]; then
@@ -967,66 +989,91 @@ function cmd_create {
 		exit 1
 	}
 
-	# Check if APPTAINER_CACHEDIR is set:
-	if [[ -d "/gscratch/scrubbed" ]]; then
-		local newcachedir
-		if [[ "${APPTAINER_CACHEDIR:-}" != /gscratch/* ]] && [[ "${APPTAINER_CACHEDIR:-}" != /tmp/* ]]; then
-			log WARN "APPTAINER_CACHEDIR is not set to a directory under /gscratch or /tmp. This may cause problems with storage space."
+	# If /gscratch/scrubbed exists (i.e., running on Klone) and APPTAINER_CACHEDIR is not set to a directory under /gscratch or /tmp, warn the user and ask if they want to set it to a directory under /gscratch/scrubbed :
+	if [[ -d "/gscratch/scrubbed" ]] && [[ "${APPTAINER_CACHEDIR:-}" != /gscratch/* ]] && [[ "${APPTAINER_CACHEDIR:-}" != /tmp/* ]]; then
+		log WARN "APPTAINER_CACHEDIR is not set to a directory under /gscratch or /tmp. This may cause problems with storage space."
 
-			# Check if running interactively:
-			if [[ -t 0 ]]; then
-				local choice1 choice2 newcachedir
-				newcachedir="/gscratch/scrubbed/${USER}/.cache/apptainer"
+		# Check if running interactively:
+		if [[ -t 0 ]]; then
+			local choice1 choice2 newcachedir
+			newcachedir="/gscratch/scrubbed/${USER}/.cache/apptainer"
 
-				# Check if should set and create APPTAINER_CACHEDIR:
-				echo "Would you like to set APPTAINER_CACHEDIR to ${newcachedir}? (Recommended)"
-				read -rp "Continue (y/n)?" choice1
+			while true; do
+				read -rp "Would you like to set APPTAINER_CACHEDIR to \"${newcachedir}\" (Recommended)? (y/n): " choice1
 				case "${choice1}" in
 				y | Y)
-					echo "Creating ${newcachedir}"
+					log INFO "Creating ${newcachedir}"
 					mkdir -p "${newcachedir}" || {
 						log WARN "Failed to create directory ${newcachedir}"
 						return 1
 					}
+					choice1=y # Set choice1 to y so we can use it in the next case statement
 					export APPTAINER_CACHEDIR="${newcachedir}"
+					break
+					;;
+				n | N)
+					log WARN "Not setting APPTAINER_CACHEDIR."
+					break
 
-					# Check if the user wants to add APPTAINER_CACHEDIR to their shell's startup file:
-					echo "Would you like to add APPTAINER_CACHEDIR to your shell's startup file to persist this setting? (Recommended)"
-					read -rp "Continue (y/n)?" choice2
+					;;
+				*)
+					log ERROR "Invalid choice ${choice1:-}."
+					;;
+				esac
+			done
+
+			if [[ "${choice1}" == "y" ]]; then
+
+				# Check if the user wants to add the directory to their shell's startup file:
+				while true; do
+					read -rp "Would you like to add APPTAINER_CACHEDIR to your shell's startup file to persist this setting? (y/n): " choice2
 					case "${choice2}" in
 					y | Y)
 						# Check if using ZSH:
 						if [[ -n "${ZSH_VERSION:-}" ]]; then
-							if [[ -r "${HOME}/.zshenv}" ]]; then
-								echo "export APPTAINER_CACHEDIR=\"${newcachedir}\"" >>"${HOME}/.zshenv" && echo "Added APPTAINER_CACHEDIR to ~/.zshenv"
+							if [[ -w "${HOME}/.zshenv}" ]]; then
+								echo "export APPTAINER_CACHEDIR=\"${newcachedir}\"" >>"${HOME}/.zshenv" && log INFO "Added APPTAINER_CACHEDIR to ~/.zshenv"
 							else
-								echo "export APPTAINER_CACHEDIR=\"${newcachedir}\"" >>"${HOME}/.zshrc" && echo "Added APPTAINER_CACHEDIR to ~/.zshrc"
+								echo "export APPTAINER_CACHEDIR=\"${newcachedir}\"" >>"${ZDOTDIR:-${HOME}}/.zshrc" && log INFO "Added APPTAINER_CACHEDIR to ${ZDOTDIR:-~}/.zshrc"
 							fi
 						# Check if using Bash:
 						elif [[ -n "${BASH_VERSION:-}" ]]; then
-							echo "export APPTAINER_CACHEDIR=\"${newcachedir}\"" >>"${HOME}/.bashrc" && echo "Added APPTAINER_CACHEDIR to ~/.bashrc"
+							echo "export APPTAINER_CACHEDIR=\"${newcachedir}\"" >>"${HOME}/.bashrc" && log INFO "Added APPTAINER_CACHEDIR to ~/.bashrc"
 						# Write to ~/.profile if we can't determine shell type:
 						else
-							echo "Could not determine shell type. Adding APPTAINER_CACHEDIR to ~/.profile."
-							echo "export APPTAINER_CACHEDIR=\"${newcachedir}\"" >>"${HOME}/.profile" && echo "Added APPTAINER_CACHEDIR to ~/.profile"
+							log INFO "Could not determine shell type. Adding APPTAINER_CACHEDIR to ~/.profile."
+							echo "export APPTAINER_CACHEDIR=\"${newcachedir}\"" >>"${HOME}/.profile" && log INFO "Added APPTAINER_CACHEDIR to ~/.profile"
 						fi
+						break
 						;;
 
-					n | N) log WARN "Not adding APPTAINER_CACHEDIR to your shell's startup file. You may need to do this again in the future." ;;
+					n | N)
+						log WARN "Not adding APPTAINER_CACHEDIR to your shell's startup file. You may need to do this again in the future."
+						break
+						;;
 					*)
 						log ERROR "Invalid choice ${choice2:-}."
-						exit 1
 						;;
 					esac
-					;;
-
-				n | N) log WARN "Not setting APPTAINER_CACHEDIR. You may encounter problems with storage space." ;;
-				*)
-					log ERROR "Invalid choice ${choice1:-}."
-					exit 1
-					;;
-				esac
+				done
 			fi
+		fi
+	fi
+
+	# Preload ORAS images if requested:
+	if [[ "${HYAKVNC_APPTAINER_GHCR_ORAS_PRELOAD:-1}" == 1 ]]; then
+		local oras_image_path oras_cache_dir
+		oras_cache_dir="${APPTAINER_CACHEDIR:-${HOME}/.apptainer/cache}/oras"
+		if mkdir -p "${oras_cache_dir}"; then
+			log INFO "Preloading ORAS image for \"${HYAKVNC_APPTAINER_CONTAINER}\""
+			oras_image_path="$(ghcr_get_oras_sif "${HYAKVNC_APPTAINER_CONTAINER}" "${APPTAINER_CACHEDIR}/oras" || true)"
+		else
+			log ERROR "Failed to create directory ${oras_cache_dir}."
+		fi
+		if [[ -n "${oras_image_path:-}" ]]; then
+			log INFO "Preloaded ORAS image for \"${HYAKVNC_APPTAINER_CONTAINER}\""
+		else
+			log ERROR "hyakvnc failed to preload ORAS image for \"${HYAKVNC_APPTAINER_CONTAINER:-}\" on its own. Apptainer will try to download the image by itself. If you don't want to preload ORAS images, use the --no-ghcr-oras-preload option."
 		fi
 	fi
 
@@ -1765,9 +1812,9 @@ function main {
 
 	case "${action}" in
 	cmd_help | cmd_install | cmd_update | cmd_config)
-	if check_slurm_running; then
-		hyakvnc_config_init || log WARN "Could't initialize config automatically" # Don't exit if config can't be initialized (e.g., not running on SLURM)
-	fi
+		if check_slurm_running; then
+			hyakvnc_config_init || log WARN "Could't initialize config automatically" # Don't exit if config can't be initialized (e.g., not running on SLURM)
+		fi
 		;;
 	*)
 		hyakvnc_config_init || exit 1                                        # Fill in default values for config variables or exit if config can't be initialized

--- a/hyakvnc
+++ b/hyakvnc
@@ -1072,11 +1072,12 @@ function cmd_create {
 
 	# Preload ORAS images if requested:
 	if [[ "${HYAKVNC_APPTAINER_GHCR_ORAS_PRELOAD:-1}" == 1 ]]; then
-		local oras_cache_dir
+		local oras_cache_dir oras_image_path
 		oras_cache_dir="${APPTAINER_CACHEDIR:-${HOME}/.apptainer/cache}/cache/oras"
 		if mkdir -p "${oras_cache_dir}"; then
 			log INFO "Preloading ORAS image for \"${HYAKVNC_APPTAINER_CONTAINER}\""
-			ghcr_get_oras_sif "${HYAKVNC_APPTAINER_CONTAINER}" "${APPTAINER_CACHEDIR}/cache/oras" || log ERROR "hyakvnc failed to preload ORAS image for \"${HYAKVNC_APPTAINER_CONTAINER:-}\" on its own. Apptainer will try to download the image by itself. If you don't want to preload ORAS images, use the --no-ghcr-oras-preload option."
+			oras_image_path="$(ghcr_get_oras_sif "${HYAKVNC_APPTAINER_CONTAINER}" "${APPTAINER_CACHEDIR}/cache/oras" 1>/dev/null || true)"
+			[[ -z "${oras_image_path:-}" ]] && log ERROR "hyakvnc failed to preload ORAS image for \"${HYAKVNC_APPTAINER_CONTAINER:-}\" on its own. Apptainer will try to download the image by itself. If you don't want to preload ORAS images, use the --no-ghcr-oras-preload option."
 		else
 			log ERROR "Failed to create directory ${oras_cache_dir}."
 		fi
@@ -1250,7 +1251,7 @@ function cmd_create {
 
 		break
 	done
-	
+
 	grep -q '^xstartup.turbovnc: Executing' <(timeout "${HYAKVNC_DEFAULT_TIMEOUT}" tail -f "${jobdir}/vnc/vnc.log" || true)
 
 	log INFO "VNC server started"

--- a/hyakvnc
+++ b/hyakvnc
@@ -1245,8 +1245,12 @@ function cmd_create {
 		[[ ! -d "${jobdir}" ]] && log TRACE "Job directory does not exist yet" && continue
 		[[ ! -e "${jobdir}/vnc/socket.uds" ]] && log TRACE "Job socket does not exist yet" && continue
 		[[ ! -S "${jobdir}/vnc/socket.uds" ]] && log TRACE "Job socket is not a socket" && continue
+		[[ ! -r "${jobdir}/vnc/vnc.log" ]] && log TRACE "VNC log file not readable yet" && continue
+
 		break
 	done
+
+	grep -q '^xstartup.turbovnc: Executing' <(timeout "${HYAKVNC_DEFAULT_TIMEOUT}" tail -f "${jobdir}/vnc/vnc.log" || true)
 
 	log INFO "VNC server started"
 	# Get details about the Xvnc process:
@@ -1256,7 +1260,7 @@ function cmd_create {
 	}
 	# Stop trapping the signals:
 	[[ -z "${XNOTRAP:-}" ]] && trap - SIGINT SIGTERM SIGHUP SIGABRT SIGQUIT ERR EXIT
-	kill -TERM %tail 2>/dev/null # Stop following the SLURM log file
+	kill -9 %tail 2>/dev/null # Stop following the SLURM log file
 	return 0
 }
 

--- a/hyakvnc
+++ b/hyakvnc
@@ -865,7 +865,7 @@ EOF
 function cmd_create {
 	local apptainer_start_args=()
 	local sbatch_args=(--parsable)
-	local container_basename container_name start
+	local container_basename container_name start tailpid
 	# <TODO> If a job ID was specified, don't launch a new job
 	# <TODO> If a job ID was specified, check that the job exists and is running
 
@@ -1213,6 +1213,7 @@ function cmd_create {
 	if check_log_level "${HYAKVNC_LOG_LEVEL}" DEBUG; then
 		echo "Streaming log from ${jobdir}/slurm.log"
 		tail -n 1 -f "${jobdir}/slurm.log" --pid=$$ 2>/dev/null | sed --unbuffered 's/^/DEBUG: slurm.log: /' & # Follow the SLURM log file in the background
+		tailpid=$!
 	fi
 
 	case "${HYAKVNC_APPTAINER_CONTAINER}" in
@@ -1249,7 +1250,7 @@ function cmd_create {
 
 		break
 	done
-
+	
 	grep -q '^xstartup.turbovnc: Executing' <(timeout "${HYAKVNC_DEFAULT_TIMEOUT}" tail -f "${jobdir}/vnc/vnc.log" || true)
 
 	log INFO "VNC server started"
@@ -1260,7 +1261,7 @@ function cmd_create {
 	}
 	# Stop trapping the signals:
 	[[ -z "${XNOTRAP:-}" ]] && trap - SIGINT SIGTERM SIGHUP SIGABRT SIGQUIT ERR EXIT
-	kill -9 %tail 2>/dev/null # Stop following the SLURM log file
+	kill -9 "${tailpid}" 2>/dev/null # Stop following the SLURM log file
 	return 0
 }
 

--- a/hyakvnc
+++ b/hyakvnc
@@ -1073,7 +1073,7 @@ function cmd_create {
 	# Preload ORAS images if requested:
 	if [[ "${HYAKVNC_APPTAINER_GHCR_ORAS_PRELOAD:-1}" == 1 ]]; then
 		local oras_image_path oras_cache_dir
-		oras_cache_dir="${APPTAINER_CACHEDIR:-${HOME}/.apptainer/cache}/oras"
+		oras_cache_dir="${APPTAINER_CACHEDIR:-${HOME}/.apptainer/cache}/cache/oras"
 		if mkdir -p "${oras_cache_dir}"; then
 			log INFO "Preloading ORAS image for \"${HYAKVNC_APPTAINER_CONTAINER}\""
 			oras_image_path="$(ghcr_get_oras_sif "${HYAKVNC_APPTAINER_CONTAINER}" "${APPTAINER_CACHEDIR}/oras" || true)"

--- a/hyakvnc
+++ b/hyakvnc
@@ -1076,7 +1076,7 @@ function cmd_create {
 		oras_cache_dir="${APPTAINER_CACHEDIR:-${HOME}/.apptainer/cache}/cache/oras"
 		if mkdir -p "${oras_cache_dir}"; then
 			log INFO "Preloading ORAS image for \"${HYAKVNC_APPTAINER_CONTAINER}\""
-			oras_image_path="$(ghcr_get_oras_sif "${HYAKVNC_APPTAINER_CONTAINER}" "${APPTAINER_CACHEDIR}/oras" || true)"
+			oras_image_path="$(ghcr_get_oras_sif "${HYAKVNC_APPTAINER_CONTAINER}" "${APPTAINER_CACHEDIR}/cache/oras" || true)"
 		else
 			log ERROR "Failed to create directory ${oras_cache_dir}."
 		fi

--- a/hyakvnc
+++ b/hyakvnc
@@ -724,7 +724,9 @@ function cleanup_launched_jobs_and_exit {
 
 # ghcr_get_oras_sif()
 # Get a GitHub Container Registry token for a given repository
-# Arguments: <url> (required)
+# Arguments:
+#  - url: URL to download from (required)
+#  - output_path: Directory or path to save the image to (optional)
 # Returns: 0 if successful, 1 if not or if an error occurred
 # Prints: The token to stdout
 function ghcr_get_oras_sif {

--- a/hyakvnc
+++ b/hyakvnc
@@ -1072,18 +1072,13 @@ function cmd_create {
 
 	# Preload ORAS images if requested:
 	if [[ "${HYAKVNC_APPTAINER_GHCR_ORAS_PRELOAD:-1}" == 1 ]]; then
-		local oras_image_path oras_cache_dir
+		local oras_cache_dir
 		oras_cache_dir="${APPTAINER_CACHEDIR:-${HOME}/.apptainer/cache}/cache/oras"
 		if mkdir -p "${oras_cache_dir}"; then
 			log INFO "Preloading ORAS image for \"${HYAKVNC_APPTAINER_CONTAINER}\""
-			oras_image_path="$(ghcr_get_oras_sif "${HYAKVNC_APPTAINER_CONTAINER}" "${APPTAINER_CACHEDIR}/cache/oras" || true)"
+			ghcr_get_oras_sif "${HYAKVNC_APPTAINER_CONTAINER}" "${APPTAINER_CACHEDIR}/cache/oras" || log ERROR "hyakvnc failed to preload ORAS image for \"${HYAKVNC_APPTAINER_CONTAINER:-}\" on its own. Apptainer will try to download the image by itself. If you don't want to preload ORAS images, use the --no-ghcr-oras-preload option."
 		else
 			log ERROR "Failed to create directory ${oras_cache_dir}."
-		fi
-		if [[ -n "${oras_image_path:-}" ]]; then
-			log INFO "Preloaded ORAS image for \"${HYAKVNC_APPTAINER_CONTAINER}\""
-		else
-			log ERROR "hyakvnc failed to preload ORAS image for \"${HYAKVNC_APPTAINER_CONTAINER:-}\" on its own. Apptainer will try to download the image by itself. If you don't want to preload ORAS images, use the --no-ghcr-oras-preload option."
 		fi
 	fi
 
@@ -1261,6 +1256,7 @@ function cmd_create {
 	}
 	# Stop trapping the signals:
 	[[ -z "${XNOTRAP:-}" ]] && trap - SIGINT SIGTERM SIGHUP SIGABRT SIGQUIT ERR EXIT
+	kill -TERM %tail 2>/dev/null # Stop following the SLURM log file
 	return 0
 }
 

--- a/hyakvnc
+++ b/hyakvnc
@@ -563,8 +563,8 @@ function stop_hyakvnc_session {
 
 	if [[ -n "${should_cancel}" ]]; then
 		log INFO "Cancelling job ${jobid}"
-		sleep 5 # Wait for VNC process to exit
-		scancel "${jobid}" || log ERROR "scancel failed to cancel job ${jobid}"
+		sleep 1 # Wait for VNC process to exit
+		scancel --full "${jobid}" || log ERROR "scancel failed to cancel job ${jobid}"
 	fi
 	return 0
 }

--- a/hyakvnc
+++ b/hyakvnc
@@ -795,7 +795,7 @@ function ghcr_get_oras_sif {
 	if [[ -r "${output_path}" ]]; then
 		log DEBUG "Image already exists at ${output_path}"
 		if check_command sha256sum; then
-			if sha256sum --quiet --status --ignore-missing --check <(echo "${output_path}" "${image_sha256##sha256:}"); then
+			if sha256sum --quiet --status --ignore-missing --check <(echo "${image_sha256##sha256:}" "${output_path}"); then
 				log DEBUG "Image at ${output_path} matches expected SHA256 ${image_sha256}"
 				echo "${output_path}"
 				return 0

--- a/install.sh
+++ b/install.sh
@@ -37,7 +37,7 @@ _install_hyakvnc() {
 	_HYAKVNC_DIR="${_HYAKVNC_DIR:-${HOME}/.hyakvnc}"                  # %% Local directory to store application data (default: `$HOME/.hyakvnc`)
 	_HYAKVNC_REPO_DIR="${_HYAKVNC_REPO_DIR:-${_HYAKVNC_DIR}/hyakvnc}" # Local directory to store git repository (default: `$HYAKVNC_DIR/hyakvnc`)
 	_HYAKVNC_REPO_URL="${_HYAKVNC_REPO_URL:-"https://github.com/maouw/hyakvnc"}"
-	_HYAKVNC_REPO_BRANCH="${_HYAKVNC_REPO_BRANCH:-"main"}"
+	_HYAKVNC_REPO_BRANCH="${_HYAKVNC_REPO_BRANCH:-"apptainer-pull-cache"}"
 
 	# shellcheck disable=SC2016
 	_UNEXPANDED_BIN_INSTALL_DIR='${HOME}/.local/bin'                          # Local directory to store executable (default: `$HOME/.local/bin`)


### PR DESCRIPTION
Preloads oras://ghcr.io SIF images for better UX -- shows download progress.

This should not be necessary as of [Apptainer v1.2.3 (2023-09-14)](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md#v123---2023-09-14):
> The `apptainer push/pull` commands now show a progress bar for the oras protocol like there was for docker and library protocols.

But `klone` has `apptainer` 1.1.5 installed. Ideally, we should be able to remove this when `klone` upgrades the `apptainer` version.

The implementation uses `curl` to query the ghcr API in roughly the same way `apptainer` does it in [`internal/pkg/client/oras/oras.go`](https://github.com/apptainer/apptainer/blob/636ab85267e29920d6c2721a983ccc2d070e516c/internal/pkg/client/oras/oras.go). It uses `python3` to parse the JSON responses and downloads the blob for the image directly to `$APPTAINER_CACHEDIR/cache/oras`, which is where `apptainer` looks for a cached image from `oras://ghcr.io` (**This `apptainer` cache behavior might change in the future.**).

If anything goes wrong, the preload will fail and `hyakvnc` will carry on. 

